### PR TITLE
Add provider login credentials to the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,6 @@
 ## Developing locally
 
 ```
-$ npm install -g docute-cli
-$ docute -p 8080 docs
+$ npm install docute-cli
+$ npx docute -p 8080 docs
 ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,7 +21,7 @@ If you are looking for the [legacy API documentation, see this](https://checkout
 
 ## Test credentials
 
-Please note that not all payment methods support testing, so only the payment methods that support testing payments are enabled for these credentials.
+Please note that not all payment methods support testing, so only the payment methods that support testing payments are enabled for these credentials. Provider specific credentials for approving payments can be found from [providers tab](/payment-method-providers#test-credentials).
 
 ### Normal merchant account
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,6 +1,6 @@
 <img src="images/checkout-logo-vaaka-RGB.png" alt="Checkout Finland Oy" style="width: 200px;">
 
-## Checkout PSP API
+# Checkout PSP API
 
 You can find example payloads and responses for all the requests, as well as [code examples](#code-examples), here.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -89,7 +89,11 @@
   <script>
     docute.init({
       nav: {
-        default: [{title: 'Home', path: '/'}, {title: 'Examples', path: '/examples'}],
+        default: [
+          { title: 'Home', path: '/' },
+          { title: 'Examples', path: '/examples' },
+          { title: 'Providers', path: '/payment-method-providers' }
+        ],
       },
       tocVisibleDepth: 3,
       announcement(route) {

--- a/docs/payment-method-providers.md
+++ b/docs/payment-method-providers.md
@@ -1,0 +1,47 @@
+<img src="images/checkout-logo-vaaka-RGB.png" alt="Checkout Finland Oy" style="width: 200px;">
+
+# Payment method providers
+
+The payment methods that can be tested without real money transactions have been enabled for the test accounts. Test credentials for the services can be found below.
+
+## Test credentials
+
+Provider | Credentials
+---------| -----------
+Masterpass | Use *IE English* Masterpass wallet and one of the [provided credit cards](https://developer.mastercard.com/page/masterpass-sandbox-testing-guidelines)
+MobilePay | Use your own phone number and MobilePay application, charges are not made with test credentials
+Osuuspankki | Username: 123456<br>Password: 7890<br>Security code: any
+Nordea | Username: 123456<br>Password: 1111<br>Security code: any
+Handelsbanken<br>POP Pankki<br>Säästöpankki<br>OmaSP | Username: 11111111<br>Password: 123456<br>Security code: 123456
+Aktia | Username: 12345678<br>Password: 123456<br>Security code: 1234
+S-Pankki | Username: 12345678<br>Password: 9999<br>Security code: 1234
+Ålandsbanken | Username: 12345678<br>Password: 1234<br>Security code: any
+Danske | Danske test account login requires using real Danske credentials
+Visa | Card number: 4153013999700024<br>Expiry date: 11/2023<br>CVC: 024
+Mastercard | Card number: 5353299308701770<br>Expiry date: 11/2023<br>CVC: 770
+Collector | Social security number: 010380-000P
+Mash | Generate a social security number with [Mash provided service](https://sc-rel.mash.com/My/Test/GenerateSsnForTesting?age=34&tps=651)
+
+## Provider limitations
+
+### General limitations
+
+Some payment method providers have minimum and/or maximum amounts for the purchases. These are not currently enforced by the API for other than Mash and AinaPay.
+
+### Refunds
+
+API refunds have been impmeneted for all providers supporting them. Currently payments created by the following methods can be refunded only with email refunds due to their lack of a refund API:
+
+* S-pankki
+* Ålandsbanken
+* AinaPay
+
+There can be limitations in the refund APIs too, eg. Nordea API allows to refund only once per payment, and only for payments created less than 13 weeks earlier.
+
+#### Refunds with test account
+
+In addition to the limitations above, the following restrictions apply for refunding test account payments:
+
+* Nordea refunds do not work
+* Aktia refunds do not work
+


### PR DESCRIPTION
* Add a new tab that lists test accounts for each supported payment method provider
* Add some notes about provider limitations