### PR TITLE
Bug in example php code

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -375,7 +375,7 @@ function calculateHmac($secret, $params, $body = '')
     });
 
     // Keys must be sorted alphabetically
-    ksort($includedKeys);
+    sort($includedKeys, SORT_STRING);
 
     $hmacPayload =
         array_map(


### PR DESCRIPTION
$includedKeys is an array with numeric keys and filtered keys from $params as values, so it needs to be sorted by values.

$includedKeys = [ 'checkout-account', 'checkout-algorithm', 'checkout-method', 'checkout-nonce', checkout-timestamp' ];