### PR TITLE
Remove AinaPay from documentation since we don't offer it anymore. Re…

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -764,7 +764,6 @@ The form field values are rendered as hidden `<input>` elements in the form. See
 | `bank`       | Bank payment methods                                                                |
 | `creditcard` | Visa, MasterCard, American Express                                                  |
 | `credit`     | Instalment and invoice payment methods: OP Lasku, Collector, Mash, Jousto, AfterPay |
-| `other`      | Miscellaneous methods: AinaPay                                                      |
 
 ### Refund payment
 

--- a/docs/payment-method-providers.md
+++ b/docs/payment-method-providers.md
@@ -26,7 +26,6 @@ Collector<br>Collector B2B | `collectorb2c`<br>`collectorb2b` |  Social security
 Mash | `mash` |  Generate a social security number with [Mash provided service](https://sc-rel.mash.com/My/Test/GenerateSsnForTesting?age=34&tps=651)
 Pivo | `pivo` | Testing is not possible
 Siirto | `siirto` | Testing is not possible
-AinaPay | `ainapay` | Testing is not possible
 OP Lasku | `oplasku` | Testing is not possible
 Jousto | `jousto` | Testing is not possible
 


### PR DESCRIPTION
…move 'other' payment method group since AinaPay was the only merchant in the group.